### PR TITLE
Fix KeyError: 'Key Bindings' on category iteration

### DIFF
--- a/tcd_browser.py
+++ b/tcd_browser.py
@@ -44,7 +44,7 @@ class TCDBrowser:
         categories = [_ for _ in tool_options.iter() if _.tag == "CATEGORY" and "NAME" in _.attrib]
 
         for category in categories:
-            for preference, option in preferences[category.get("NAME")].items():
+            for preference, option in preferences.get(category.get("NAME"), {}).items():
                 element = [_ for _ in category.iter() if _.get("NAME") == preference]
 
                 # Check if the preference exists or not


### PR DESCRIPTION
This fixes an error with the tcd_browser.py module on a fresh install of **Ghidra 9.2.0 PUBLIC**.

```
Traceback (most recent call last):
  File "install.py", line 112, in <module>
    browser.update(preferences)
  File "/home/user/Development/personal/ghidra_themes/ghidra-dark/tcd_browser.py", line 47, in update
    for preference, option in preferences[category.get("NAME")].items():
KeyError: 'Key Bindings'
```