### PR TITLE
Replace formdev.com link with mvnrepository.com for collecting FlatLaf 0.43

### DIFF
--- a/install.py
+++ b/install.py
@@ -53,7 +53,7 @@ with open(properties_path, "r") as fp:
 print(f"Detected Ghidra v{version}")
 
 flatlaf_path = os.path.join(install_path, "flatlaf-0.43.jar")
-flatlaf_url = "https://bintray.com/jformdesigner/flatlaf/download_file?file_path=com/formdev/flatlaf/0.43/flatlaf-0.43.jar"
+flatlaf_url = "https://repo1.maven.org/maven2/com/formdev/flatlaf/0.43/flatlaf-0.43.jar"
 
 # Download the FlatLaf jar
 if not os.path.exists(flatlaf_path):


### PR DESCRIPTION
As metioned in #10, I cannot attest to whether https://mvnrepository.com/ is a trustable site for collecting this file. I have, done some tests on this and found it to work. The new URL that I am using is https://mvnrepository.com/artifact/com.formdev/flatlaf/0.43. 

Please feel free to make the changes you feel are necessary to this PR. 

~Lyell