### PR TITLE
Add support for detecting the Arch community package install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ ghidra-dark provides a simple to use script to install the FlatLaf dark theme, c
 $ python3 install.py
 ```
 
+If installing as root (e.g. `sudo`), the user to install for may need to be specified:
+
+```
+$ sudo python3 install.py -u [user]
+```
+
 ![](ghidra-dark.png)
 
 ## Uninstall

--- a/install.py
+++ b/install.py
@@ -47,6 +47,16 @@ def get_ghidra_install_path(install_path: str = None) -> str:
         return install_path
     # Attempt to find the installation directory based on `ghidraRun`
     ghidra_run_path = shutil.which("ghidraRun")
+
+    if not ghidra_run_path:
+        # Arch package uses a symlink in `/usr/bin/ghidra` to ghidraRun
+        ghidra_symlink_path = shutil.which("ghidra")
+        if os.path.islink(ghidra_symlink_path):
+            try:
+                ghidra_run_path = os.readlink(ghidra_symlink_path)
+            except:
+                ghidra_run_path = None
+
     if not ghidra_run_path:
         return None
     return Path(ghidra_run_path).resolve().parents[0]


### PR DESCRIPTION
The arch community package for ghidra (and, to my understanding, the ghidra-git and ghidra-dev packages as well) includes a symlink from `/usr/bin/ghidra` to `ghidraRun` (which is not itself in PATH). This PR adds support for detecting installs via the presence of such a symlink in the PATH.